### PR TITLE
Add unit tests with Bun test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "src/index.ts",
   "scripts": {
     "start": "bun run src/index.ts",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "bun test"
   },
   "repository": {
     "type": "git",

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, mock, beforeEach, afterEach, spyOn } from "bun:test";
+import type { Credentials } from "google-auth-library";
+import {
+  loadCredentials,
+  loadCachedToken,
+  saveToken,
+  refreshTokenIfNeeded,
+} from "../auth";
+
+describe("loadCredentials", () => {
+  let originalBunFile: typeof Bun.file;
+
+  beforeEach(() => {
+    originalBunFile = Bun.file;
+  });
+
+  afterEach(() => {
+    (Bun as any).file = originalBunFile;
+  });
+
+  it("returns parsed credentials when file exists and is valid", async () => {
+    const validCredentials = {
+      installed: {
+        client_id: "test-client-id",
+        client_secret: "test-client-secret",
+        redirect_uris: ["http://localhost"],
+      },
+    };
+
+    (Bun as any).file = mock(() => ({
+      exists: () => Promise.resolve(true),
+      text: () => Promise.resolve(JSON.stringify(validCredentials)),
+    }));
+
+    const result = await loadCredentials();
+
+    expect(result).toEqual(validCredentials);
+  });
+
+  it("throws descriptive error when file is missing", async () => {
+    (Bun as any).file = mock(() => ({
+      exists: () => Promise.resolve(false),
+    }));
+
+    await expect(loadCredentials()).rejects.toThrow(
+      "Missing credentials.json"
+    );
+  });
+
+  it("throws parse error for invalid JSON", async () => {
+    (Bun as any).file = mock(() => ({
+      exists: () => Promise.resolve(true),
+      text: () => Promise.resolve("not valid json"),
+    }));
+
+    await expect(loadCredentials()).rejects.toThrow(
+      "Failed to parse credentials.json"
+    );
+  });
+});
+
+describe("loadCachedToken", () => {
+  let originalBunFile: typeof Bun.file;
+
+  beforeEach(() => {
+    originalBunFile = Bun.file;
+  });
+
+  afterEach(() => {
+    (Bun as any).file = originalBunFile;
+  });
+
+  it("returns token when file exists and is valid", async () => {
+    const validToken: Credentials = {
+      access_token: "test-access-token",
+      refresh_token: "test-refresh-token",
+      expiry_date: Date.now() + 3600000,
+    };
+
+    (Bun as any).file = mock(() => ({
+      exists: () => Promise.resolve(true),
+      text: () => Promise.resolve(JSON.stringify(validToken)),
+    }));
+
+    const result = await loadCachedToken();
+
+    expect(result).toEqual(validToken);
+  });
+
+  it("returns null when file is missing", async () => {
+    (Bun as any).file = mock(() => ({
+      exists: () => Promise.resolve(false),
+    }));
+
+    const result = await loadCachedToken();
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null for invalid JSON", async () => {
+    (Bun as any).file = mock(() => ({
+      exists: () => Promise.resolve(true),
+      text: () => Promise.resolve("invalid json"),
+    }));
+
+    const result = await loadCachedToken();
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("saveToken", () => {
+  let originalBunWrite: typeof Bun.write;
+  let mockConsoleLog: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    originalBunWrite = Bun.write;
+    mockConsoleLog = spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    (Bun as any).write = originalBunWrite;
+    mockConsoleLog.mockRestore();
+  });
+
+  it("writes token to token.json", async () => {
+    const mockWrite = mock(() => Promise.resolve(100));
+    (Bun as any).write = mockWrite;
+
+    const token: Credentials = {
+      access_token: "test-token",
+      refresh_token: "test-refresh",
+      expiry_date: 1234567890,
+    };
+
+    await saveToken(token);
+
+    expect(mockWrite).toHaveBeenCalledTimes(1);
+    expect(mockWrite.mock.calls[0][0]).toBe("token.json");
+
+    // Verify the written content is properly formatted JSON
+    const writtenContent = mockWrite.mock.calls[0][1] as string;
+    const parsedContent = JSON.parse(writtenContent);
+    expect(parsedContent).toEqual(token);
+  });
+
+  it("logs success message after saving", async () => {
+    (Bun as any).write = mock(() => Promise.resolve(100));
+
+    const token: Credentials = {
+      access_token: "test-token",
+    };
+
+    await saveToken(token);
+
+    expect(mockConsoleLog).toHaveBeenCalledWith("Token saved to token.json");
+  });
+});
+
+describe("refreshTokenIfNeeded", () => {
+  let mockConsoleLog: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    mockConsoleLog = spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    mockConsoleLog.mockRestore();
+  });
+
+  it("returns original token when not expired", async () => {
+    const token: Credentials = {
+      access_token: "valid-token",
+      refresh_token: "refresh-token",
+      expiry_date: Date.now() + 3600000, // 1 hour from now
+    };
+
+    const mockOAuth2Client = {
+      setCredentials: mock(() => {}),
+    };
+
+    const result = await refreshTokenIfNeeded(mockOAuth2Client as any, token);
+
+    expect(result).toEqual(token);
+    expect(mockOAuth2Client.setCredentials).toHaveBeenCalledWith(token);
+  });
+
+  it("refreshes token when expiring within 5 minutes", async () => {
+    // Save and restore Bun.write
+    const originalBunWrite = Bun.write;
+    (Bun as any).write = mock(() => Promise.resolve(100));
+
+    try {
+      const oldToken: Credentials = {
+        access_token: "old-token",
+        refresh_token: "refresh-token",
+        expiry_date: Date.now() + 60000, // 1 minute from now (within 5 min buffer)
+      };
+
+      const newCredentials: Credentials = {
+        access_token: "new-token",
+        expiry_date: Date.now() + 3600000,
+      };
+
+      const mockOAuth2Client = {
+        setCredentials: mock(() => {}),
+        refreshAccessToken: mock(() =>
+          Promise.resolve({ credentials: newCredentials })
+        ),
+      };
+
+      const result = await refreshTokenIfNeeded(mockOAuth2Client as any, oldToken);
+
+      expect(mockOAuth2Client.refreshAccessToken).toHaveBeenCalled();
+      expect(result.access_token).toBe("new-token");
+      // Should preserve the original refresh_token
+      expect(result.refresh_token).toBe("refresh-token");
+    } finally {
+      (Bun as any).write = originalBunWrite;
+    }
+  });
+
+  it("refreshes token when expired", async () => {
+    const originalBunWrite = Bun.write;
+    (Bun as any).write = mock(() => Promise.resolve(100));
+
+    try {
+      const oldToken: Credentials = {
+        access_token: "old-token",
+        refresh_token: "refresh-token",
+        expiry_date: Date.now() - 60000, // Already expired
+      };
+
+      const newCredentials: Credentials = {
+        access_token: "new-token",
+        expiry_date: Date.now() + 3600000,
+      };
+
+      const mockOAuth2Client = {
+        setCredentials: mock(() => {}),
+        refreshAccessToken: mock(() =>
+          Promise.resolve({ credentials: newCredentials })
+        ),
+      };
+
+      const result = await refreshTokenIfNeeded(mockOAuth2Client as any, oldToken);
+
+      expect(mockOAuth2Client.refreshAccessToken).toHaveBeenCalled();
+      expect(result.access_token).toBe("new-token");
+    } finally {
+      (Bun as any).write = originalBunWrite;
+    }
+  });
+
+  it("throws when token expired and no refresh_token available", async () => {
+    const expiredToken: Credentials = {
+      access_token: "old-token",
+      // No refresh_token
+      expiry_date: Date.now() - 60000, // Already expired
+    };
+
+    const mockOAuth2Client = {
+      setCredentials: mock(() => {}),
+    };
+
+    await expect(
+      refreshTokenIfNeeded(mockOAuth2Client as any, expiredToken)
+    ).rejects.toThrow("Token expired and no refresh token available");
+  });
+
+  it("re-throws error when refresh fails", async () => {
+    const oldToken: Credentials = {
+      access_token: "old-token",
+      refresh_token: "refresh-token",
+      expiry_date: Date.now() - 60000,
+    };
+
+    const mockOAuth2Client = {
+      setCredentials: mock(() => {}),
+      refreshAccessToken: mock(() =>
+        Promise.reject(new Error("Refresh failed"))
+      ),
+    };
+
+    await expect(
+      refreshTokenIfNeeded(mockOAuth2Client as any, oldToken)
+    ).rejects.toThrow("Refresh failed");
+  });
+
+  it("returns token unchanged when no expiry_date", async () => {
+    const token: Credentials = {
+      access_token: "valid-token",
+      refresh_token: "refresh-token",
+      // No expiry_date
+    };
+
+    const mockOAuth2Client = {
+      setCredentials: mock(() => {}),
+    };
+
+    const result = await refreshTokenIfNeeded(mockOAuth2Client as any, token);
+
+    expect(result).toEqual(token);
+  });
+});

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, mock, beforeEach, afterEach, spyOn } from "bun:test";
+import { parseArgs, formatBytes } from "../index";
+
+describe("parseArgs", () => {
+  let mockExit: ReturnType<typeof spyOn>;
+  let mockConsoleError: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    // Mock process.exit to prevent test from actually exiting
+    mockExit = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+    mockConsoleError = spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    mockExit.mockRestore();
+    mockConsoleError.mockRestore();
+  });
+
+  it("returns query with default output when only query provided", () => {
+    const result = parseArgs(["from:test@example.com"]);
+
+    expect(result.query).toBe("from:test@example.com");
+    expect(result.output).toBe("attachments.zip");
+    expect(result.help).toBe(false);
+  });
+
+  it("sets custom output with -o flag", () => {
+    const result = parseArgs(["query", "-o", "custom.zip"]);
+
+    expect(result.query).toBe("query");
+    expect(result.output).toBe("custom.zip");
+    expect(result.help).toBe(false);
+  });
+
+  it("sets custom output with --output flag", () => {
+    const result = parseArgs(["query", "--output", "myfile.zip"]);
+
+    expect(result.query).toBe("query");
+    expect(result.output).toBe("myfile.zip");
+    expect(result.help).toBe(false);
+  });
+
+  it("sets help flag with -h", () => {
+    const result = parseArgs(["-h"]);
+
+    expect(result.help).toBe(true);
+  });
+
+  it("sets help flag with --help", () => {
+    const result = parseArgs(["--help"]);
+
+    expect(result.help).toBe(true);
+  });
+
+  it("returns empty query when no arguments provided", () => {
+    const result = parseArgs([]);
+
+    expect(result.query).toBe("");
+    expect(result.output).toBe("attachments.zip");
+    expect(result.help).toBe(false);
+  });
+
+  it("handles query before options", () => {
+    const result = parseArgs(["has:attachment", "-o", "out.zip"]);
+
+    expect(result.query).toBe("has:attachment");
+    expect(result.output).toBe("out.zip");
+  });
+
+  it("handles query after options", () => {
+    const result = parseArgs(["-o", "out.zip", "has:attachment"]);
+
+    expect(result.query).toBe("has:attachment");
+    expect(result.output).toBe("out.zip");
+  });
+
+  it("handles help with other arguments", () => {
+    const result = parseArgs(["query", "-h", "-o", "file.zip"]);
+
+    expect(result.help).toBe(true);
+    expect(result.query).toBe("query");
+    expect(result.output).toBe("file.zip");
+  });
+
+  it("exits with error when -o has no value", () => {
+    expect(() => parseArgs(["-o"])).toThrow("process.exit called");
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("exits with error for unknown option", () => {
+    expect(() => parseArgs(["--unknown"])).toThrow("process.exit called");
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("handles complex query strings", () => {
+    const complexQuery = "from:sender@test.com has:attachment larger:1M after:2024/01/01";
+    const result = parseArgs([complexQuery]);
+
+    expect(result.query).toBe(complexQuery);
+  });
+});
+
+describe("formatBytes", () => {
+  it("formats 0 bytes", () => {
+    expect(formatBytes(0)).toBe("0 B");
+  });
+
+  it("formats bytes under 1KB", () => {
+    expect(formatBytes(500)).toBe("500 B");
+    expect(formatBytes(1)).toBe("1 B");
+    expect(formatBytes(1023)).toBe("1023 B");
+  });
+
+  it("formats exactly 1KB", () => {
+    expect(formatBytes(1024)).toBe("1.0 KB");
+  });
+
+  it("formats KB values", () => {
+    expect(formatBytes(1536)).toBe("1.5 KB");
+    expect(formatBytes(2048)).toBe("2.0 KB");
+    expect(formatBytes(10240)).toBe("10.0 KB");
+  });
+
+  it("formats exactly 1MB", () => {
+    expect(formatBytes(1048576)).toBe("1.0 MB");
+  });
+
+  it("formats MB values", () => {
+    expect(formatBytes(1572864)).toBe("1.5 MB");
+    expect(formatBytes(5242880)).toBe("5.0 MB");
+    expect(formatBytes(10485760)).toBe("10.0 MB");
+  });
+
+  it("formats large MB values", () => {
+    expect(formatBytes(104857600)).toBe("100.0 MB");
+    expect(formatBytes(1073741824)).toBe("1024.0 MB");
+  });
+
+  it("handles boundary values correctly", () => {
+    // Just under 1KB
+    expect(formatBytes(1023)).toBe("1023 B");
+    // Just under 1MB
+    expect(formatBytes(1048575)).toBe("1024.0 KB");
+  });
+});

--- a/src/__tests__/gmail.test.ts
+++ b/src/__tests__/gmail.test.ts
@@ -1,0 +1,620 @@
+import { describe, it, expect, mock, beforeEach, afterEach, spyOn } from "bun:test";
+import type { gmail_v1 } from "googleapis";
+import {
+  extractAttachments,
+  withRetry,
+  searchMessages,
+  getMessageAttachments,
+  downloadAttachment,
+} from "../gmail";
+
+describe("extractAttachments", () => {
+  it("returns empty array for undefined parts", () => {
+    const result = extractAttachments(undefined, "msg123");
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array for empty parts array", () => {
+    const result = extractAttachments([], "msg123");
+    expect(result).toEqual([]);
+  });
+
+  it("extracts single attachment from parts", () => {
+    const parts: gmail_v1.Schema$MessagePart[] = [
+      {
+        filename: "document.pdf",
+        mimeType: "application/pdf",
+        body: {
+          attachmentId: "att123",
+          size: 1024,
+        },
+      },
+    ];
+
+    const result = extractAttachments(parts, "msg123");
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      attachmentId: "att123",
+      filename: "document.pdf",
+      mimeType: "application/pdf",
+      size: 1024,
+      messageId: "msg123",
+    });
+  });
+
+  it("extracts multiple attachments from parts", () => {
+    const parts: gmail_v1.Schema$MessagePart[] = [
+      {
+        filename: "file1.txt",
+        mimeType: "text/plain",
+        body: { attachmentId: "att1", size: 100 },
+      },
+      {
+        filename: "file2.pdf",
+        mimeType: "application/pdf",
+        body: { attachmentId: "att2", size: 200 },
+      },
+    ];
+
+    const result = extractAttachments(parts, "msg123");
+
+    expect(result).toHaveLength(2);
+    expect(result[0].filename).toBe("file1.txt");
+    expect(result[1].filename).toBe("file2.pdf");
+  });
+
+  it("extracts attachments from nested multipart", () => {
+    const parts: gmail_v1.Schema$MessagePart[] = [
+      {
+        mimeType: "multipart/alternative",
+        parts: [
+          {
+            filename: "nested.doc",
+            mimeType: "application/msword",
+            body: { attachmentId: "att_nested", size: 500 },
+          },
+        ],
+      },
+      {
+        filename: "top_level.pdf",
+        mimeType: "application/pdf",
+        body: { attachmentId: "att_top", size: 1000 },
+      },
+    ];
+
+    const result = extractAttachments(parts, "msg123");
+
+    expect(result).toHaveLength(2);
+    expect(result.find((a) => a.filename === "nested.doc")).toBeDefined();
+    expect(result.find((a) => a.filename === "top_level.pdf")).toBeDefined();
+  });
+
+  it("skips parts without attachmentId", () => {
+    const parts: gmail_v1.Schema$MessagePart[] = [
+      {
+        filename: "inline.txt",
+        mimeType: "text/plain",
+        body: { size: 100 }, // No attachmentId
+      },
+      {
+        filename: "attachment.pdf",
+        mimeType: "application/pdf",
+        body: { attachmentId: "att123", size: 200 },
+      },
+    ];
+
+    const result = extractAttachments(parts, "msg123");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].filename).toBe("attachment.pdf");
+  });
+
+  it("skips parts with empty filename", () => {
+    const parts: gmail_v1.Schema$MessagePart[] = [
+      {
+        filename: "",
+        mimeType: "text/plain",
+        body: { attachmentId: "att123", size: 100 },
+      },
+      {
+        filename: "valid.pdf",
+        mimeType: "application/pdf",
+        body: { attachmentId: "att456", size: 200 },
+      },
+    ];
+
+    const result = extractAttachments(parts, "msg123");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].filename).toBe("valid.pdf");
+  });
+
+  it("uses default mimeType when not provided", () => {
+    const parts: gmail_v1.Schema$MessagePart[] = [
+      {
+        filename: "unknown.bin",
+        body: { attachmentId: "att123", size: 100 },
+      },
+    ];
+
+    const result = extractAttachments(parts, "msg123");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].mimeType).toBe("application/octet-stream");
+  });
+
+  it("uses 0 as default size when not provided", () => {
+    const parts: gmail_v1.Schema$MessagePart[] = [
+      {
+        filename: "file.txt",
+        mimeType: "text/plain",
+        body: { attachmentId: "att123" },
+      },
+    ];
+
+    const result = extractAttachments(parts, "msg123");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].size).toBe(0);
+  });
+});
+
+describe("withRetry", () => {
+  let mockConsoleWarn: ReturnType<typeof spyOn>;
+  let mockSleep: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    mockConsoleWarn = spyOn(console, "warn").mockImplementation(() => {});
+    mockSleep = spyOn(Bun, "sleep").mockImplementation(() => Promise.resolve());
+  });
+
+  afterEach(() => {
+    mockConsoleWarn.mockRestore();
+    mockSleep.mockRestore();
+  });
+
+  it("returns result on first successful try", async () => {
+    const operation = mock(() => Promise.resolve("success"));
+
+    const result = await withRetry(operation, "test operation");
+
+    expect(result).toBe("success");
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on 429 rate limit error", async () => {
+    let attempts = 0;
+    const operation = mock(() => {
+      attempts++;
+      if (attempts === 1) {
+        const error = new Error("Rate limited") as Error & { code: number };
+        error.code = 429;
+        return Promise.reject(error);
+      }
+      return Promise.resolve("success");
+    });
+
+    const result = await withRetry(operation, "test operation");
+
+    expect(result).toBe("success");
+    expect(operation).toHaveBeenCalledTimes(2);
+    expect(mockSleep).toHaveBeenCalled();
+  });
+
+  it("retries on 5xx server errors", async () => {
+    let attempts = 0;
+    const operation = mock(() => {
+      attempts++;
+      if (attempts === 1) {
+        const error = new Error("Server error") as Error & { code: number };
+        error.code = 500;
+        return Promise.reject(error);
+      }
+      return Promise.resolve("success");
+    });
+
+    const result = await withRetry(operation, "test operation");
+
+    expect(result).toBe("success");
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on 503 service unavailable", async () => {
+    let attempts = 0;
+    const operation = mock(() => {
+      attempts++;
+      if (attempts === 1) {
+        const error = new Error("Service unavailable") as Error & { code: number };
+        error.code = 503;
+        return Promise.reject(error);
+      }
+      return Promise.resolve("success");
+    });
+
+    const result = await withRetry(operation, "test operation");
+
+    expect(result).toBe("success");
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry on 404 error", async () => {
+    const error = new Error("Not found") as Error & { code: number };
+    error.code = 404;
+    const operation = mock(() => Promise.reject(error));
+
+    await expect(withRetry(operation, "test operation")).rejects.toThrow(
+      "test operation: Resource not found"
+    );
+
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry on 400 bad request", async () => {
+    const error = new Error("Bad request") as Error & { code: number };
+    error.code = 400;
+    const operation = mock(() => Promise.reject(error));
+
+    await expect(withRetry(operation, "test operation")).rejects.toThrow(
+      "test operation: Invalid request"
+    );
+
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws after max retries exceeded", async () => {
+    const error = new Error("Rate limited") as Error & { code: number };
+    error.code = 429;
+    const operation = mock(() => Promise.reject(error));
+
+    await expect(withRetry(operation, "test operation", 3)).rejects.toThrow(
+      "test operation: Failed after 3 attempts"
+    );
+
+    expect(operation).toHaveBeenCalledTimes(3);
+  });
+
+  it("uses exponential backoff delays", async () => {
+    const error = new Error("Rate limited") as Error & { code: number };
+    error.code = 429;
+    const operation = mock(() => Promise.reject(error));
+
+    await expect(withRetry(operation, "test operation", 3)).rejects.toThrow();
+
+    // With 3 retries (attempts 0, 1, 2), sleep is called after attempts 0, 1, 2 before giving up
+    // But the last attempt doesn't sleep before throwing, so we get sleeps after attempts 0 and 1
+    // Actually with the loop: attempt 0 fails -> sleep 1s, attempt 1 fails -> sleep 2s, attempt 2 fails -> throw
+    // So 2 sleeps total (no sleep before first attempt, no sleep after last failed attempt)
+    // Wait, looking at the code more carefully:
+    // for attempt 0: try, fail with 429, sleep(1s), continue
+    // for attempt 1: try, fail with 429, sleep(2s), continue
+    // for attempt 2: try, fail with 429, sleep(4s), continue
+    // then loop ends and throws
+    // So it's actually 3 sleeps
+    expect(mockSleep).toHaveBeenCalledTimes(3);
+    expect(mockSleep).toHaveBeenNthCalledWith(1, 1000);
+    expect(mockSleep).toHaveBeenNthCalledWith(2, 2000);
+    expect(mockSleep).toHaveBeenNthCalledWith(3, 4000);
+  });
+
+  it("does not retry on unknown errors", async () => {
+    const error = new Error("Unknown error");
+    const operation = mock(() => Promise.reject(error));
+
+    await expect(withRetry(operation, "test operation")).rejects.toThrow(
+      "Unknown error"
+    );
+
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("searchMessages", () => {
+  it("returns message IDs from response", async () => {
+    const mockList = mock(() =>
+      Promise.resolve({
+        data: {
+          messages: [{ id: "msg1" }, { id: "msg2" }, { id: "msg3" }],
+          nextPageToken: undefined,
+        },
+      })
+    );
+
+    const mockGmail = {
+      users: {
+        messages: {
+          list: mockList,
+        },
+      },
+    };
+
+    // Mock the google.gmail function
+    const { google } = await import("googleapis");
+    const originalGmail = google.gmail;
+    google.gmail = (() => mockGmail) as typeof google.gmail;
+
+    try {
+      const mockAuth = {} as any;
+      const result = await searchMessages(mockAuth, "has:attachment");
+
+      expect(result).toEqual(["msg1", "msg2", "msg3"]);
+      expect(mockList).toHaveBeenCalled();
+    } finally {
+      google.gmail = originalGmail;
+    }
+  });
+
+  it("handles pagination with multiple pages", async () => {
+    let callCount = 0;
+    const mockList = mock(() => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.resolve({
+          data: {
+            messages: [{ id: "msg1" }, { id: "msg2" }],
+            nextPageToken: "token123",
+          },
+        });
+      }
+      return Promise.resolve({
+        data: {
+          messages: [{ id: "msg3" }],
+          nextPageToken: undefined,
+        },
+      });
+    });
+
+    const mockGmail = {
+      users: {
+        messages: {
+          list: mockList,
+        },
+      },
+    };
+
+    const { google } = await import("googleapis");
+    const originalGmail = google.gmail;
+    google.gmail = (() => mockGmail) as typeof google.gmail;
+
+    try {
+      const mockAuth = {} as any;
+      const result = await searchMessages(mockAuth, "has:attachment");
+
+      expect(result).toEqual(["msg1", "msg2", "msg3"]);
+      expect(mockList).toHaveBeenCalledTimes(2);
+    } finally {
+      google.gmail = originalGmail;
+    }
+  });
+
+  it("returns empty array when no messages found", async () => {
+    const mockList = mock(() =>
+      Promise.resolve({
+        data: {
+          messages: undefined,
+          nextPageToken: undefined,
+        },
+      })
+    );
+
+    const mockGmail = {
+      users: {
+        messages: {
+          list: mockList,
+        },
+      },
+    };
+
+    const { google } = await import("googleapis");
+    const originalGmail = google.gmail;
+    google.gmail = (() => mockGmail) as typeof google.gmail;
+
+    try {
+      const mockAuth = {} as any;
+      const result = await searchMessages(mockAuth, "has:attachment");
+
+      expect(result).toEqual([]);
+    } finally {
+      google.gmail = originalGmail;
+    }
+  });
+});
+
+describe("getMessageAttachments", () => {
+  it("extracts attachments from multipart message", async () => {
+    const mockGet = mock(() =>
+      Promise.resolve({
+        data: {
+          payload: {
+            parts: [
+              {
+                filename: "test.pdf",
+                mimeType: "application/pdf",
+                body: { attachmentId: "att123", size: 1024 },
+              },
+            ],
+          },
+        },
+      })
+    );
+
+    const mockGmail = {
+      users: {
+        messages: {
+          get: mockGet,
+        },
+      },
+    };
+
+    const { google } = await import("googleapis");
+    const originalGmail = google.gmail;
+    google.gmail = (() => mockGmail) as typeof google.gmail;
+
+    try {
+      const mockAuth = {} as any;
+      const result = await getMessageAttachments(mockAuth, "msg123");
+
+      expect(result).toHaveLength(1);
+      expect(result[0].filename).toBe("test.pdf");
+      expect(result[0].messageId).toBe("msg123");
+    } finally {
+      google.gmail = originalGmail;
+    }
+  });
+
+  it("handles single-part message with attachment", async () => {
+    const mockGet = mock(() =>
+      Promise.resolve({
+        data: {
+          payload: {
+            filename: "single.txt",
+            mimeType: "text/plain",
+            body: { attachmentId: "att456", size: 100 },
+          },
+        },
+      })
+    );
+
+    const mockGmail = {
+      users: {
+        messages: {
+          get: mockGet,
+        },
+      },
+    };
+
+    const { google } = await import("googleapis");
+    const originalGmail = google.gmail;
+    google.gmail = (() => mockGmail) as typeof google.gmail;
+
+    try {
+      const mockAuth = {} as any;
+      const result = await getMessageAttachments(mockAuth, "msg123");
+
+      expect(result).toHaveLength(1);
+      expect(result[0].filename).toBe("single.txt");
+      expect(result[0].attachmentId).toBe("att456");
+    } finally {
+      google.gmail = originalGmail;
+    }
+  });
+});
+
+describe("downloadAttachment", () => {
+  it("decodes base64url data correctly", async () => {
+    // "hello world" in base64url
+    const base64urlData = "aGVsbG8gd29ybGQ";
+
+    const mockGet = mock(() =>
+      Promise.resolve({
+        data: {
+          data: base64urlData,
+        },
+      })
+    );
+
+    const mockGmail = {
+      users: {
+        messages: {
+          attachments: {
+            get: mockGet,
+          },
+        },
+      },
+    };
+
+    const { google } = await import("googleapis");
+    const originalGmail = google.gmail;
+    google.gmail = (() => mockGmail) as typeof google.gmail;
+
+    try {
+      const mockAuth = {} as any;
+      const result = await downloadAttachment(
+        mockAuth,
+        "msg123",
+        "att456",
+        "test.txt"
+      );
+
+      expect(result.filename).toBe("test.txt");
+      expect(result.data.toString()).toBe("hello world");
+    } finally {
+      google.gmail = originalGmail;
+    }
+  });
+
+  it("throws on missing data", async () => {
+    const mockGet = mock(() =>
+      Promise.resolve({
+        data: {
+          data: undefined,
+        },
+      })
+    );
+
+    const mockGmail = {
+      users: {
+        messages: {
+          attachments: {
+            get: mockGet,
+          },
+        },
+      },
+    };
+
+    const { google } = await import("googleapis");
+    const originalGmail = google.gmail;
+    google.gmail = (() => mockGmail) as typeof google.gmail;
+
+    try {
+      const mockAuth = {} as any;
+      await expect(
+        downloadAttachment(mockAuth, "msg123", "att456", "test.txt")
+      ).rejects.toThrow('No data in attachment "test.txt"');
+    } finally {
+      google.gmail = originalGmail;
+    }
+  });
+
+  it("handles binary data with base64url encoding", async () => {
+    // Binary data encoded as base64url
+    const binaryBuffer = Buffer.from([0x00, 0x01, 0xff, 0xfe]);
+    const base64urlData = binaryBuffer.toString("base64url");
+
+    const mockGet = mock(() =>
+      Promise.resolve({
+        data: {
+          data: base64urlData,
+        },
+      })
+    );
+
+    const mockGmail = {
+      users: {
+        messages: {
+          attachments: {
+            get: mockGet,
+          },
+        },
+      },
+    };
+
+    const { google } = await import("googleapis");
+    const originalGmail = google.gmail;
+    google.gmail = (() => mockGmail) as typeof google.gmail;
+
+    try {
+      const mockAuth = {} as any;
+      const result = await downloadAttachment(
+        mockAuth,
+        "msg123",
+        "att456",
+        "binary.bin"
+      );
+
+      expect(result.data).toEqual(binaryBuffer);
+    } finally {
+      google.gmail = originalGmail;
+    }
+  });
+});

--- a/src/__tests__/zip.test.ts
+++ b/src/__tests__/zip.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, mock, spyOn } from "bun:test";
+import { deduplicateFilenames, createZip, type FileEntry } from "../zip";
+
+describe("deduplicateFilenames", () => {
+  it("returns files unchanged when no duplicates", () => {
+    const files: FileEntry[] = [
+      { filename: "file1.txt", data: Buffer.from("data1") },
+      { filename: "file2.txt", data: Buffer.from("data2") },
+      { filename: "file3.pdf", data: Buffer.from("data3") },
+    ];
+
+    const result = deduplicateFilenames(files);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].filename).toBe("file1.txt");
+    expect(result[1].filename).toBe("file2.txt");
+    expect(result[2].filename).toBe("file3.pdf");
+  });
+
+  it("appends _1 to second occurrence of duplicate", () => {
+    const files: FileEntry[] = [
+      { filename: "file.txt", data: Buffer.from("data1") },
+      { filename: "file.txt", data: Buffer.from("data2") },
+    ];
+
+    const result = deduplicateFilenames(files);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].filename).toBe("file.txt");
+    expect(result[1].filename).toBe("file_1.txt");
+  });
+
+  it("appends _1, _2, etc for multiple duplicates", () => {
+    const files: FileEntry[] = [
+      { filename: "doc.pdf", data: Buffer.from("data1") },
+      { filename: "doc.pdf", data: Buffer.from("data2") },
+      { filename: "doc.pdf", data: Buffer.from("data3") },
+      { filename: "doc.pdf", data: Buffer.from("data4") },
+    ];
+
+    const result = deduplicateFilenames(files);
+
+    expect(result).toHaveLength(4);
+    expect(result[0].filename).toBe("doc.pdf");
+    expect(result[1].filename).toBe("doc_1.pdf");
+    expect(result[2].filename).toBe("doc_2.pdf");
+    expect(result[3].filename).toBe("doc_3.pdf");
+  });
+
+  it("handles files without extensions", () => {
+    const files: FileEntry[] = [
+      { filename: "README", data: Buffer.from("data1") },
+      { filename: "README", data: Buffer.from("data2") },
+      { filename: "Makefile", data: Buffer.from("data3") },
+    ];
+
+    const result = deduplicateFilenames(files);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].filename).toBe("README");
+    expect(result[1].filename).toBe("README_1");
+    expect(result[2].filename).toBe("Makefile");
+  });
+
+  it("handles files with multiple dots (e.g., file.tar.gz)", () => {
+    const files: FileEntry[] = [
+      { filename: "archive.tar.gz", data: Buffer.from("data1") },
+      { filename: "archive.tar.gz", data: Buffer.from("data2") },
+    ];
+
+    const result = deduplicateFilenames(files);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].filename).toBe("archive.tar.gz");
+    // Note: current implementation uses lastIndexOf so it splits at last dot
+    expect(result[1].filename).toBe("archive.tar_1.gz");
+  });
+
+  it("handles empty array", () => {
+    const files: FileEntry[] = [];
+    const result = deduplicateFilenames(files);
+    expect(result).toHaveLength(0);
+  });
+
+  it("handles mixed duplicates and unique files", () => {
+    const files: FileEntry[] = [
+      { filename: "a.txt", data: Buffer.from("1") },
+      { filename: "b.txt", data: Buffer.from("2") },
+      { filename: "a.txt", data: Buffer.from("3") },
+      { filename: "c.txt", data: Buffer.from("4") },
+      { filename: "a.txt", data: Buffer.from("5") },
+    ];
+
+    const result = deduplicateFilenames(files);
+
+    expect(result).toHaveLength(5);
+    expect(result[0].filename).toBe("a.txt");
+    expect(result[1].filename).toBe("b.txt");
+    expect(result[2].filename).toBe("a_1.txt");
+    expect(result[3].filename).toBe("c.txt");
+    expect(result[4].filename).toBe("a_2.txt");
+  });
+});
+
+describe("createZip", () => {
+  it("creates a valid ZIP buffer with files", async () => {
+    const files: FileEntry[] = [
+      { filename: "test.txt", data: Buffer.from("hello world") },
+    ];
+
+    const result = await createZip(files);
+
+    // ZIP files start with PK signature (0x504B)
+    expect(result).toBeInstanceOf(Buffer);
+    expect(result.length).toBeGreaterThan(0);
+    expect(result[0]).toBe(0x50); // 'P'
+    expect(result[1]).toBe(0x4b); // 'K'
+  });
+
+  it("creates ZIP with multiple files", async () => {
+    const files: FileEntry[] = [
+      { filename: "file1.txt", data: Buffer.from("content1") },
+      { filename: "file2.txt", data: Buffer.from("content2") },
+      { filename: "file3.txt", data: Buffer.from("content3") },
+    ];
+
+    const result = await createZip(files);
+
+    expect(result).toBeInstanceOf(Buffer);
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("handles duplicate filenames by deduplicating", async () => {
+    const files: FileEntry[] = [
+      { filename: "same.txt", data: Buffer.from("first") },
+      { filename: "same.txt", data: Buffer.from("second") },
+    ];
+
+    // This should not throw - deduplication handles it
+    const result = await createZip(files);
+
+    expect(result).toBeInstanceOf(Buffer);
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("creates ZIP with empty file array", async () => {
+    const files: FileEntry[] = [];
+
+    const result = await createZip(files);
+
+    // Empty ZIP is still a valid ZIP file
+    expect(result).toBeInstanceOf(Buffer);
+  });
+
+  it("handles binary data correctly", async () => {
+    // Create binary data with all byte values
+    const binaryData = Buffer.alloc(256);
+    for (let i = 0; i < 256; i++) {
+      binaryData[i] = i;
+    }
+
+    const files: FileEntry[] = [
+      { filename: "binary.bin", data: binaryData },
+    ];
+
+    const result = await createZip(files);
+
+    expect(result).toBeInstanceOf(Buffer);
+    expect(result.length).toBeGreaterThan(0);
+  });
+});

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -112,6 +112,9 @@ async function refreshTokenIfNeeded(
   return token;
 }
 
+// Export internal functions for testing
+export { loadCredentials, loadCachedToken, saveToken, refreshTokenIfNeeded };
+
 // T2.5 - Main authorize function
 export async function authorize(): Promise<OAuth2Client> {
   const credentials = await loadCredentials();

--- a/src/gmail.ts
+++ b/src/gmail.ts
@@ -156,6 +156,9 @@ export async function getMessageAttachments(
   return extractAttachments(message.payload?.parts, messageId);
 }
 
+// Export internal functions for testing
+export { extractAttachments, withRetry };
+
 // T3.3 - Download a single attachment
 export async function downloadAttachment(
   auth: OAuth2Client,

--- a/src/index.ts
+++ b/src/index.ts
@@ -247,8 +247,13 @@ async function main(): Promise<void> {
   process.exit(EXIT_SUCCESS);
 }
 
-// Run main
-main().catch((error) => {
-  console.error("Unexpected error:", error);
-  process.exit(EXIT_API_ERROR);
-});
+// Export functions for testing
+export { parseArgs, formatBytes };
+
+// Run main only when executed directly (not when imported for testing)
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error("Unexpected error:", error);
+    process.exit(EXIT_API_ERROR);
+  });
+}


### PR DESCRIPTION
- Add 72 unit tests across 4 test files covering zip, cli, gmail, and auth modules
- Export internal functions from source files for testing
- Update package.json test script to use bun test
- Wrap main() execution in import.meta.main check to allow importing without side effects